### PR TITLE
fix sentinel configuration

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -34,6 +34,9 @@ if [ -n "$SENTINEL" ]; then
     Configure $CONF 'port' "$SENTINEL_PORT"
     Configure $CONF 'sentinel announce-ip' "$ANNOUNCE_IP"
     Configure $CONF 'sentinel announce-port' "$SENTINEL_PORT" 
+    Configure $CONF 'sentinel down-after-milliseconds' "$MASTER_NAME 30000"
+    Configure $CONF 'sentinel parallel-syncs' "$MASTER_NAME 1"
+    Configure $CONF 'sentinel failover-timeout' "$MASTER_NAME 180000"
     CMD='redis-sentinel'
     
 else

--- a/config/sentinel.conf
+++ b/config/sentinel.conf
@@ -77,7 +77,6 @@ dir /tmp
 # Down).
 #
 # Default is 30 seconds.
-sentinel down-after-milliseconds mymaster 30000
 
 # sentinel parallel-syncs <master-name> <numslaves>
 #
@@ -85,7 +84,6 @@ sentinel down-after-milliseconds mymaster 30000
 # during the failover. Use a low number if you use the slaves to serve query
 # to avoid that all the slaves will be unreachable at about the same
 # time while performing the synchronization with the master.
-sentinel parallel-syncs mymaster 1
 
 # sentinel failover-timeout <master-name> <milliseconds>
 #
@@ -110,7 +108,6 @@ sentinel parallel-syncs mymaster 1
 #   the exact parallel-syncs progression as specified.
 #
 # Default is 3 minutes.
-sentinel failover-timeout mymaster 180000
 
 # SCRIPTS EXECUTION
 #


### PR DESCRIPTION
Added ability to manipulate `master_name`, before it was hardcoded to `mymaster`