### PR TITLE
Match entire config key instead of just prefix

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -8,7 +8,7 @@ Configure() {
 
     if [[ "$VAL" != "" ]]; then
         CONFIG_LINE="$VAR $VAL"
-        sed -e "s/\(^#*\ *$VAR\(.*\)$\)/$CONFIG_LINE/g" $CONFIG_FILE > /tmp/config.tmp && mv -f /tmp/config.tmp $CONFIG_FILE
+        sed -e "s/\(^#*\ *$VAR \(.*\)$\)/$CONFIG_LINE/g" $CONFIG_FILE > /tmp/config.tmp && mv -f /tmp/config.tmp $CONFIG_FILE
 
         grep "^$CONFIG_LINE" $CONFIG_FILE
 


### PR DESCRIPTION
The problem is: if this container starts with a environment variable like `CONFIGS=maxmemory=9999`, all three keys `maxmemory`, `maxmemory-policy` and `maxmemory-samples` will get replaced by `maxmemory 9999` because we're matching just prefix, not entire key